### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Node.js server implementing Model Context Protocol (MCP) for [TaskWarrior](https://taskwarrior.org/) operations.
 
+<a href="https://glama.ai/mcp/servers/e8w3e1su1x">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/e8w3e1su1x/badge" alt="TaskWarrior Server MCP server" />
+</a>
+
 ## Features
 
 - View pending tasks


### PR DESCRIPTION
This PR adds a badge for the [TaskWarrior MCP Server](https://glama.ai/mcp/servers/e8w3e1su1x) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/e8w3e1su1x">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/e8w3e1su1x/badge" alt="TaskWarrior Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.