### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Node.js server implementing Model Context Protocol (MCP) for [TaskWarrior](https
 > sometimes renumbers tasks when new ones are added or removed. In the future
 > this should be more careful, using task UUID instead.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/awwaiid-mcp-server-taskwarrior).
+
 ## API
 
 ### Tools


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/awwaiid-mcp-server-taskwarrior).